### PR TITLE
separate convert function (subset of convertAndBuffer)

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -37,12 +37,12 @@ downloadVultures <- function(loginObject, extraSensors = F, removeDup = T,
 
   if(quiet == T){
     dat <- suppressWarnings(suppressMessages(move::getMovebankData(study = "Ornitela_Vultures_Gyps_fulvus_TAU_UCLA_Israel",
-                                 login = loginObject,
-                                 includeExtraSensors = FALSE,
-                                 deploymentAsIndividuals = FALSE,
-                                 removeDuplicatedTimestamps = TRUE,
-                                 timestamp_start = dateTimeStartUTC,
-                                 timestamp_end = dateTimeEndUTC)))
+                                                                   login = loginObject,
+                                                                   includeExtraSensors = FALSE,
+                                                                   deploymentAsIndividuals = FALSE,
+                                                                   removeDuplicatedTimestamps = TRUE,
+                                                                   timestamp_start = dateTimeStartUTC,
+                                                                   timestamp_end = dateTimeEndUTC)))
   }else{
     dat <- move::getMovebankData(study = "Ornitela_Vultures_Gyps_fulvus_TAU_UCLA_Israel",
                                  login = loginObject,
@@ -716,8 +716,26 @@ computeProbs <- function(graphList){
   return(histdfLong)
 }
 
-#' Buffer an sf object
+#' Convert coordinates of an sf object
 #'
+#' Given an sf object in WGS84, convert it to a CRS with meters as the units.
+#' @param obj an sf object to be buffered
+#' @param crsMeters crs with units of meters to be used. Default is 32636 (Israel, UTM zone 36)
+#' @return A buffered sf object
+#' @export
+convertAndBuffer <- function(obj, dist = 50, crsMeters = 32636){
+  checkmate::assertClass(obj, "sf")
+  originalCRS <- sf::st_crs(obj)
+  if(is.null(originalCRS)){
+    stop("Object does not have a valid CRS.")
+  }
+
+  converted <- obj %>%
+    sf::st_transform(crsMeters)
+
+  return(converted)
+}
+
 #' Given an sf object in WGS84, convert it to a CRS with meters as the units, buffer by a given distance, and then convert it back.
 #' @param obj an sf object to be buffered
 #' @param dist buffer distance, in meters (m)

--- a/man/convertAndBuffer.Rd
+++ b/man/convertAndBuffer.Rd
@@ -2,8 +2,10 @@
 % Please edit documentation in R/funs.R
 \name{convertAndBuffer}
 \alias{convertAndBuffer}
-\title{Buffer an sf object}
+\title{Convert coordinates of an sf object}
 \usage{
+convertAndBuffer(obj, dist = 50, crsMeters = 32636)
+
 convertAndBuffer(obj, dist = 50, crsMeters = 32636)
 }
 \arguments{
@@ -15,7 +17,9 @@ convertAndBuffer(obj, dist = 50, crsMeters = 32636)
 }
 \value{
 A buffered sf object
+
+A buffered sf object
 }
 \description{
-Given an sf object in WGS84, convert it to a CRS with meters as the units, buffer by a given distance, and then convert it back.
+Given an sf object in WGS84, convert it to a CRS with meters as the units.
 }


### PR DESCRIPTION
Added a convert function, which is basically a wrapper on sf::st_transform() without needing to remember the syntax. Maybe this is stupid; I don't know.

Closes #20. I don't think we need a separate buffer function.