### PR TITLE
Crucial bug fixes for get*Edges wrapper functions

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -116,20 +116,31 @@ getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distT
   # Exclude any points that fall within a (buffered) roost polygon
   points <- dataset[lengths(sf::st_intersects(dataset, roostPolygons)) == 0,]
 
-  if(quiet == T){
-    edges <- suppressWarnings(vultureUtils::spaceTimeGroups(dataset = points,
-                                                            distThreshold = distThreshold,
-                                                            consecThreshold = consecThreshold,
-                                                            timeThreshold = timeThreshold))
+  # If there are no rows left after filtering, return an empty data frame with the appropriate format.
+  if(nrow(points) == 0){
+    dummy <- data.frame(timegroup = as.integer(),
+                        ID1 = as.character(),
+                        ID2 = as.character(),
+                        distance = as.numeric(),
+                        minTimestamp = as.POSIXct(character()),
+                        maxTimestamp = as.POSIXct(character()))
+    return(dummy)
   }else{
-    edges <- vultureUtils::spaceTimeGroups(dataset = points,
-                                           distThreshold = distThreshold,
-                                           consecThreshold = consecThreshold,
-                                           timeThreshold = timeThreshold)
-  }
+    if(quiet == T){
+      edges <- suppressWarnings(vultureUtils::spaceTimeGroups(dataset = points,
+                                                              distThreshold = distThreshold,
+                                                              consecThreshold = consecThreshold,
+                                                              timeThreshold = timeThreshold))
+    }else{
+      edges <- vultureUtils::spaceTimeGroups(dataset = points,
+                                             distThreshold = distThreshold,
+                                             consecThreshold = consecThreshold,
+                                             timeThreshold = timeThreshold)
+    }
 
-  # Return the edge list
-  return(edges)
+    # Return the edge list
+    return(edges)
+  }
 }
 
 #' Create co-feeding edge list
@@ -167,18 +178,29 @@ getFeedingEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThre
   # Exclude any points that fall within a (buffered) roost polygon
   feedingPoints <- dataset[lengths(sf::st_intersects(dataset, roostPolygons)) == 0,]
 
-  if(quiet == T){
-    feedingEdges <- suppressWarnings(vultureUtils::spaceTimeGroups(dataset = feedingPoints, distThreshold = distThreshold,
-                                                  consecThreshold = consecThreshold,
-                                                  timeThreshold = timeThreshold))
+  # If there are no rows left after filtering, return an empty data frame with the appropriate format.
+  if(nrow(points) == 0){
+    dummy <- data.frame(timegroup = as.integer(),
+                        ID1 = as.character(),
+                        ID2 = as.character(),
+                        distance = as.numeric(),
+                        minTimestamp = as.POSIXct(character()),
+                        maxTimestamp = as.POSIXct(character()))
+    return(dummy)
   }else{
-    feedingEdges <- vultureUtils::spaceTimeGroups(dataset = feedingPoints, distThreshold = distThreshold,
-                                                  consecThreshold = consecThreshold,
-                                                  timeThreshold = timeThreshold)
-  }
+    if(quiet == T){
+      feedingEdges <- suppressWarnings(vultureUtils::spaceTimeGroups(dataset = feedingPoints, distThreshold = distThreshold,
+                                                                     consecThreshold = consecThreshold,
+                                                                     timeThreshold = timeThreshold))
+    }else{
+      feedingEdges <- vultureUtils::spaceTimeGroups(dataset = feedingPoints, distThreshold = distThreshold,
+                                                    consecThreshold = consecThreshold,
+                                                    timeThreshold = timeThreshold)
+    }
 
-  # Return the edge list
-  return(feedingEdges)
+    # Return the edge list
+    return(feedingEdges)
+  }
 }
 
 #' Create co-flight edge list
@@ -216,20 +238,30 @@ getFlightEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThres
   # Exclude any points that fall within a (buffered) roost polygon
   flightPoints <- dataset[lengths(sf::st_intersects(dataset, roostPolygons)) == 0,]
 
-  # Create edge list using spaceTimeGroups
-  if(quiet == T){
-    flightEdges <- suppressWarnings(vultureUtils::spaceTimeGroups(dataset = flightPoints, distThreshold = distThreshold,
-                                                 consecThreshold = consecThreshold,
-                                                 timeThreshold = timeThreshold))
+  # If there are no rows left after filtering, return an empty data frame with the appropriate format.
+  if(nrow(points) == 0){
+    dummy <- data.frame(timegroup = as.integer(),
+                        ID1 = as.character(),
+                        ID2 = as.character(),
+                        distance = as.numeric(),
+                        minTimestamp = as.POSIXct(character()),
+                        maxTimestamp = as.POSIXct(character()))
+    return(dummy)
   }else{
-    flightEdges <- vultureUtils::spaceTimeGroups(dataset = flightPoints, distThreshold = distThreshold,
-                                                 consecThreshold = consecThreshold,
-                                                 timeThreshold = timeThreshold)
+    # Create edge list using spaceTimeGroups
+    if(quiet == T){
+      flightEdges <- suppressWarnings(vultureUtils::spaceTimeGroups(dataset = flightPoints, distThreshold = distThreshold,
+                                                                    consecThreshold = consecThreshold,
+                                                                    timeThreshold = timeThreshold))
+    }else{
+      flightEdges <- vultureUtils::spaceTimeGroups(dataset = flightPoints, distThreshold = distThreshold,
+                                                   consecThreshold = consecThreshold,
+                                                   timeThreshold = timeThreshold)
+    }
+
+    # Return the edge list
+    return(flightEdges)
   }
-
-
-  # Return the edge list
-  return(flightEdges)
 }
 
 #' #' Create co-roosting edge list XXX START HERE

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -124,6 +124,7 @@ getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distT
                         distance = as.numeric(),
                         minTimestamp = as.POSIXct(character()),
                         maxTimestamp = as.POSIXct(character()))
+    warning("After filtering, the dataset had 0 rows. Returning an empty edge list.")
     return(dummy)
   }else{
     if(quiet == T){
@@ -186,6 +187,7 @@ getFeedingEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThre
                         distance = as.numeric(),
                         minTimestamp = as.POSIXct(character()),
                         maxTimestamp = as.POSIXct(character()))
+    warning("After filtering, the dataset had 0 rows. Returning an empty edge list.")
     return(dummy)
   }else{
     if(quiet == T){
@@ -246,6 +248,7 @@ getFlightEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThres
                         distance = as.numeric(),
                         minTimestamp = as.POSIXct(character()),
                         maxTimestamp = as.POSIXct(character()))
+    warning("After filtering, the dataset had 0 rows. Returning an empty edge list.")
     return(dummy)
   }else{
     # Create edge list using spaceTimeGroups

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -114,7 +114,7 @@ getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distT
   roostPolygons <- convertAndBuffer(roostPolygons, dist = roostBuffer)
 
   # Exclude any points that fall within a (buffered) roost polygon
-  points <- dataset[lengths(sf::st_intersects(dataset, roostPolygons)) == 0,]
+  points <- filteredData[lengths(sf::st_intersects(filteredData, roostPolygons)) == 0,]
 
   # If there are no rows left after filtering, return an empty data frame with the appropriate format.
   if(nrow(points) == 0){
@@ -177,10 +177,10 @@ getFeedingEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThre
   roostPolygons <- convertAndBuffer(roostPolygons, dist = roostBuffer)
 
   # Exclude any points that fall within a (buffered) roost polygon
-  feedingPoints <- dataset[lengths(sf::st_intersects(dataset, roostPolygons)) == 0,]
+  feedingPoints <- filteredData[lengths(sf::st_intersects(filteredData, roostPolygons)) == 0,]
 
   # If there are no rows left after filtering, return an empty data frame with the appropriate format.
-  if(nrow(points) == 0){
+  if(nrow(feedingPoints) == 0){
     dummy <- data.frame(timegroup = as.integer(),
                         ID1 = as.character(),
                         ID2 = as.character(),
@@ -238,10 +238,10 @@ getFlightEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThres
   roostPolygons <- convertAndBuffer(roostPolygons, dist = roostBuffer)
 
   # Exclude any points that fall within a (buffered) roost polygon
-  flightPoints <- dataset[lengths(sf::st_intersects(dataset, roostPolygons)) == 0,]
+  flightPoints <- filteredData[lengths(sf::st_intersects(filteredData, roostPolygons)) == 0,]
 
   # If there are no rows left after filtering, return an empty data frame with the appropriate format.
-  if(nrow(points) == 0){
+  if(nrow(flightPoints) == 0){
     dummy <- data.frame(timegroup = as.integer(),
                         ID1 = as.character(),
                         ID2 = as.character(),

--- a/man/downloadVultures.Rd
+++ b/man/downloadVultures.Rd
@@ -12,7 +12,8 @@ downloadVultures(
   dateTimeEndUTC = NULL,
   addDateOnly = T,
   dfConvert = T,
-  quiet = F
+  quiet = F,
+  ...
 )
 }
 \arguments{


### PR DESCRIPTION
Fixed two bugs:
1. An edge case where the functions would fail if no points matched the filter criteria.
2. A really big mistake whereby the filtering wasn't getting applied at all (yikes!)

Closes #24 and #25.