### PR TITLE
replaced two more instances of lapply with map. Closes #29.

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -651,12 +651,10 @@ computeProbs <- function(graphList){
     as.matrix()
 
   # get edge list for each element of the graph list
-  els <- lapply(graphList, igraph::get.edgelist)
+  els <- map(graphList, igraph::get.edgelist)
 
   # for each graph, check whether each edge is present or not
-  tf <- lapply(els, function(x){
-    complete_edgelist %in% x
-  })
+  tf <- map(els, ~complete_edgelist %in% .x)
 
   # bind into a data frame showing presence/absence of edges over time.
   overTime <- do.call(cbind, tf) %>% as.data.frame()


### PR DESCRIPTION
Quick fix for #29. There were only two `lapply` calls left, surprisingly.