### PR TITLE
Slightly generalized coord handling beyond just ITM

### DIFF
--- a/R/mainFunctions.R
+++ b/R/mainFunctions.R
@@ -384,9 +384,10 @@ getFlightEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThres
 #' @param dateCol Name of the column in `dataset` containing roost dates. Default is "date".
 #' @param roostCol Name of the column in `dataset` containing roost site assignments. Required only if `mode` = "polygon" AND `roostPolygons` is NULL.
 #' @param crsToSet CRS to assign to `dataset` if it is not already an sf object. Default is "WGS84".
+#' @param crsToTransform CRS to transform the `dataset` to. Default is "32636" for ITM.
 #' @param return One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)
 #' @export
-getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, distThreshold = 500, latCol = "location_lat", longCol = "location_long", idCol = "trackId", dateCol = "date", roostCol = "roostID", crsToSet = "WGS84", return = "edges"){
+getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, distThreshold = 500, latCol = "location_lat", longCol = "location_long", idCol = "trackId", dateCol = "date", roostCol = "roostID", crsToSet = "WGS84", crsToTransform = 32636, return = "edges"){
   # Arg checks
   checkmate::assertDataFrame(dataset)
   checkmate::assertSubset(mode, c("distance", "polygon"), empty.ok = F)
@@ -434,7 +435,7 @@ getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, dist
     dataset <- dataset %>%
       dplyr::mutate(lon = sf::st_coordinates(.)[,1],
                     lat = sf::st_coordinates(.)[,2]) %>%
-      sf::st_transform(32636) %>% # convert to UTM: we'll need this for calculating distance later.
+      sf::st_transform(crsToTransform) %>% # convert to UTM: we'll need this for calculating distance later.
       dplyr::mutate(utmE = sf::st_coordinates(.)[,1],
                     utmN = sf::st_coordinates(.)[,2]) %>%
       sf::st_drop_geometry() # spatsoc won't work if this is still an sf object.
@@ -702,7 +703,7 @@ get_roosts_df <- function(df, id = "local_identifier", timestamp = "timestamp", 
   # complete the time message
   if(!quiet){
     end <- Sys.time()
-    duration <- difftime(end, start, units = "seconds")
+    duration <- difftime(end, start, units = "secs")
     cat(paste0("Roost computation completed in ", duration, " seconds."))
   }
 

--- a/man/getRoostEdges.Rd
+++ b/man/getRoostEdges.Rd
@@ -15,6 +15,7 @@ getRoostEdges(
   dateCol = "date",
   roostCol = "roostID",
   crsToSet = "WGS84",
+  crsToTransform = 32636,
   return = "edges"
 )
 }
@@ -38,6 +39,8 @@ getRoostEdges(
 \item{roostCol}{Name of the column in `dataset` containing roost site assignments. Required only if `mode` = "polygon" AND `roostPolygons` is NULL.}
 
 \item{crsToSet}{CRS to assign to `dataset` if it is not already an sf object. Default is "WGS84".}
+
+\item{crsToTransform}{CRS to transform the `dataset` to. Default is "32636" for ITM.}
 
 \item{return}{One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)}
 }

--- a/man/spaceTimeGroups.Rd
+++ b/man/spaceTimeGroups.Rd
@@ -9,6 +9,7 @@ spaceTimeGroups(
   distThreshold,
   consecThreshold = 2,
   crsToSet = "WGS84",
+  crsToTransform = 32636,
   timestampCol = "timestamp",
   timeThreshold = "10 minutes",
   idCol = "trackId",
@@ -27,6 +28,8 @@ spaceTimeGroups(
 \item{consecThreshold}{Passed to vultureUtils::consecEdges. In how many consecutive time groups must the two individuals interact in order to be included? Default is 2.}
 
 \item{crsToSet}{if `feedingSites` is a data frame, what CRS to pass to sf::st_set_crs() (NOT transform!). If `feedingSites` is already an sf object, `crsToSet` will be overridden by whatever the object's CRS is, unless it is NA.}
+
+\item{crsToTransform}{CRS to transform the `dataset` to. Default is "32636" for ITM.}
 
 \item{timestampCol}{Passed to spatsoc::group_times. Name of date time column(s). either 1 POSIXct or 2 IDate and ITime. e.g.: 'datetime' or c('idate', 'itime')}
 


### PR DESCRIPTION
Added option to specify a crs to transform to. This isn't great because it still assumes that the crs you pass is a UTM crs. Also still maintains the verbiage "latCol" and "longCol" when it really should generalize those. I really just need to overhaul the entire handling of the spatial stuff in these functions.

So this is really just a patch. But I think it will work for Karen's thing for now.