### PR TITLE
Remove dependency on trackId

### DIFF
--- a/R/mainFunctions.R
+++ b/R/mainFunctions.R
@@ -85,13 +85,14 @@ downloadVultures <- function(loginObject, extraSensors = F, removeDup = T,
 #' @param longCol The name of the column in the dataset containing longitude values. Defaults to "location_long.1". Passed to `vultureUtils::maskData()`.
 #' @param latCol The name of the column in the dataset containing latitude values. Defaults to "location_lat.1". Passed to `vultureUtils::maskData()`.
 #' @param dateCol The name of the column in the dataset containing dates. Defaults to "dateOnly". Passed to `vultureUtils::mostlyInMask()`.
+#' @param idCol The name of the column in the dataset containing vulture ID's. Defaults to "Nili_id" (assuming you have joined the Nili_ids from the who's who table).
 #' @param removeVars Whether or not to remove unnecessary variables. Default is T.
 #' @param reMask Whether or not to re-mask after removing individuals that spend less than `inMaskThreshold` in the mask area. Default is T.
 #' @param quiet Whether to silence the message that happens when doing spatial joins. Default is T.
 #' @param ... additional arguments to be passed to any of several functions: `vultureUtils::removeUnnecessaryVars()` (`addlVars`, `keepVars`);
-#' @return An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the trackID of the first individual in this edge, and `ID2` is the trackID of the second individual in this edge.
+#' @return An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.
 #' @export
-cleanData <- function(dataset, mask, inMaskThreshold = 0.33, crs = "WGS84", longCol = "location_long.1", latCol = "location_lat.1", dateCol = "dateOnly", removeVars = T, reMask = T, quiet = T, ...){
+cleanData <- function(dataset, mask, inMaskThreshold = 0.33, crs = "WGS84", longCol = "location_long.1", latCol = "location_lat.1", dateCol = "dateOnly", idCol = "Nili_id", removeVars = T, reMask = T, quiet = T, ...){
   # Argument checks
   checkmate::assertClass(mask, "sf")
   checkmate::assertDataFrame(dataset)
@@ -157,7 +158,7 @@ cleanData <- function(dataset, mask, inMaskThreshold = 0.33, crs = "WGS84", long
     }
 
     dataset <- dataset %>% # using datDF because we don't want to actually restrict it to the mask yet
-      dplyr::filter(.data$trackId %in% longEnoughIndivs)
+      dplyr::filter(.data[[idCol]] %in% longEnoughIndivs)
   }
 
   # Mask again to remove out-of-mask points, if desired
@@ -195,7 +196,7 @@ cleanData <- function(dataset, mask, inMaskThreshold = 0.33, crs = "WGS84", long
 #' @param includeAllVertices logical. Whether to include another list item in the output that's a vector of all individuals in the dataset. For use in creating sparse graphs. Default is F.
 #' @param daytimeOnly T/F, whether to restrict interactions to daytime only. Default is T.
 #' @param return One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)
-#' @return An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the trackID of the first individual in this edge, and `ID2` is the trackID of the second individual in this edge.
+#' @return An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.
 #' @export
 getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distThreshold, speedThreshUpper, speedThreshLower, timeThreshold = "10 minutes", quiet = T, includeAllVertices = F, daytimeOnly = T, return = "edges"){
   # Argument checks
@@ -218,7 +219,7 @@ getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distT
 
   # Get all unique individuals before applying any filtering
   if(includeAllVertices){
-    uniqueIndivs <- unique(dataset$trackId)
+    uniqueIndivs <- unique(dataset[[idCol]])
   }
 
   ## FILTER THE POINTS
@@ -285,7 +286,8 @@ getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distT
                                              distThreshold = distThreshold,
                                              consecThreshold = consecThreshold,
                                              timeThreshold = timeThreshold,
-                                             sri = FALSE)
+                                             sri = FALSE,
+                                             idCol = idCol)
       }
 
     }else if(return %in% c("sri", "both")){ # otherwise we need to compute SRI.
@@ -296,7 +298,8 @@ getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distT
                                                                                distThreshold = distThreshold,
                                                                                consecThreshold = consecThreshold,
                                                                                timeThreshold = timeThreshold,
-                                                                               sri = TRUE)))
+                                                                               sri = TRUE,
+                                                                               idCol = idCol)))
         if(return == "sri"){
           out <- out["sri"]
         }
@@ -307,7 +310,8 @@ getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distT
                                              distThreshold = distThreshold,
                                              consecThreshold = consecThreshold,
                                              timeThreshold = timeThreshold,
-                                             sri = TRUE)
+                                             sri = TRUE,
+                                             idCol = idCol)
         if(return == "sri"){
           out <- out["sri"]
         }
@@ -346,7 +350,7 @@ getEdges <- function(dataset, roostPolygons, roostBuffer, consecThreshold, distT
 #' @param includeAllVertices logical. Whether to include another list item in the output that's a vector of all individuals in the dataset. For use in creating sparse graphs. Default is F.
 #' @param daytimeOnly T/F, whether to restrict interactions to daytime only. Default is T.
 #' @param return One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)
-#' @return An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the trackID of the first individual in this edge, and `ID2` is the trackID of the second individual in this edge.
+#' @return An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.
 #' @export
 getFeedingEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThreshold = 2, distThreshold = 50, speedThreshUpper = 5, speedThreshLower = NULL, timeThreshold = "10 minutes", quiet = T, includeAllVertices = F, daytimeOnly = T, return = "edges"){
   getEdges(dataset, roostPolygons = roostPolygons, roostBuffer = roostBuffer, consecThreshold = consecThreshold, distThreshold = distThreshold, speedThreshUpper = speedThreshUpper, speedThreshLower = speedThreshLower, timeThreshold = timeThreshold, quiet = quiet, includeAllVertices = includeAllVertices, daytimeOnly = daytimeOnly, return = return)
@@ -367,7 +371,7 @@ getFeedingEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThre
 #' @param includeAllVertices logical. Whether to include another list item in the output that's a vector of all individuals in the dataset. For use in creating sparse graphs. Default is F.
 #' @param daytimeOnly T/F, whether to restrict interactions to daytime only. Default is T.
 #' @param return One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)
-#' @return An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the trackID of the first individual in this edge, and `ID2` is the trackID of the second individual in this edge.
+#' @return An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.
 #' @export
 getFlightEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThreshold = 2, distThreshold = 1000, speedThreshUpper = NULL, speedThreshLower = 5, timeThreshold = "10 minutes", quiet = T, includeAllVertices = F, daytimeOnly = T, return = "edges"){
   getEdges(dataset, roostPolygons = roostPolygons, roostBuffer = roostBuffer, consecThreshold = consecThreshold, distThreshold = distThreshold, speedThreshUpper = speedThreshUpper, speedThreshLower = speedThreshLower, timeThreshold = timeThreshold, quiet = quiet, includeAllVertices = includeAllVertices, daytimeOnly = daytimeOnly, return = return)
@@ -382,14 +386,14 @@ getFlightEdges <- function(dataset, roostPolygons, roostBuffer = 50, consecThres
 #' @param distThreshold A distance threshold, in meters, below which points are considered to be "interacting"--applies only to `mode` = "distance". Default is 500m.
 #' @param latCol Name of the column in `dataset` containing latitude information. Default is "location_lat".
 #' @param longCol Name of the column in `dataset` containing longitude information. Default is "location_long".
-#' @param idCol Name of the column in `dataset` containing the ID's of the vultures. Default is "trackId".
+#' @param idCol Name of the column in `dataset` containing the ID's of the vultures. Default is "Nili_id".
 #' @param dateCol Name of the column in `dataset` containing roost dates. Default is "date".
 #' @param roostCol Name of the column in `dataset` containing roost site assignments. Required only if `mode` = "polygon" AND `roostPolygons` is NULL.
 #' @param crsToSet CRS to assign to `dataset` if it is not already an sf object. Default is "WGS84".
 #' @param crsToTransform CRS to transform the `dataset` to. Default is "32636" for ITM.
 #' @param return One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)
 #' @export
-getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, distThreshold = 500, latCol = "location_lat", longCol = "location_long", idCol = "trackId", dateCol = "date", roostCol = "roostID", crsToSet = "WGS84", crsToTransform = 32636, return = "edges"){
+getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, distThreshold = 500, latCol = "location_lat", longCol = "location_long", idCol = "Nili_id", dateCol = "date", roostCol = "roostID", crsToSet = "WGS84", crsToTransform = 32636, return = "edges"){
   # Arg checks
   checkmate::assertDataFrame(dataset)
   checkmate::assertSubset(mode, c("distance", "polygon"), empty.ok = F)

--- a/R/supportingFunctions.R
+++ b/R/supportingFunctions.R
@@ -50,16 +50,17 @@ maskData <- function(dataset, mask, longCol = "location_long", latCol = "locatio
 #' @param maskedDataset the dataset after being masked to Israel (output of maskIsrael function)
 #' @param thresh proportion (between 0 and 1) of a vulture's total tracked days that it spent in Israel
 #' @param dateCol the name of the column containing dates (must be the same in `dataset` and `maskedDataset`). Defaults to "dateOnly".
-#' @return A vector of trackIds for vultures
+#' @param idCol the name of the column containing vulture ID's.
+#' @return A vector of id's for vultures
 #' @export
-mostlyInMask <- function(dataset, maskedDataset, thresh = 0.333, dateCol = "dateOnly"){
+mostlyInMask <- function(dataset, maskedDataset, thresh = 0.333, dateCol = "dateOnly", idCol = "Nili_id"){
   # argument checks
   checkmate::assertDataFrame(dataset)
   checkmate::assertDataFrame(maskedDataset)
   checkmate::assertNumeric(thresh, len = 1, lower = 0, upper = 1)
   checkmate::assertCharacter(dateCol, len = 1)
-  checkmate::assertSubset("trackId", names(dataset))
-  checkmate::assertSubset("trackId", names(maskedDataset))
+  checkmate::assertSubset(idCol, names(dataset))
+  checkmate::assertSubset(idCol, names(maskedDataset))
   checkmate::assertSubset(dateCol, names(dataset))
   checkmate::assertSubset(dateCol, names(maskedDataset))
   # check that the `dateCol` columns actually are dates.
@@ -68,7 +69,7 @@ mostlyInMask <- function(dataset, maskedDataset, thresh = 0.333, dateCol = "date
 
   # Look at date durations in the full dataset
   dates <- dataset %>%
-    dplyr::group_by(.data$trackId) %>%
+    dplyr::group_by(.data[[idCol]]) %>%
     dplyr::summarize(duration = as.numeric(max(.data[[dateCol]],
                                                na.rm = T) - min(.data[[dateCol]],
                                                                 na.rm = T)))
@@ -77,20 +78,20 @@ mostlyInMask <- function(dataset, maskedDataset, thresh = 0.333, dateCol = "date
   # Look at date durations in the masked Israel dataset
   datesInMask <- maskedDataset %>%
     as.data.frame() %>%
-    dplyr::group_by(.data$trackId) %>%
+    dplyr::group_by(.data[[idCol]]) %>%
     dplyr::summarize(duration =
                        as.numeric(max(.data[[dateCol]], na.rm = T) -
                                     min(.data[[dateCol]], na.rm = T)))
 
   # Compare the two dates and calculate proportion
   datesCompare <- dplyr::left_join(dates, datesInMask %>%
-                                     dplyr::select(.data$trackId,
+                                     dplyr::select(.data[[idCol]],
                                                    "durationInMask" = .data$duration)) %>%
     dplyr::mutate(propInMask = .data$durationInMask/.data$duration) # compute proportion of days spent in the mask area
 
   whichInMaskLongEnough <- datesCompare %>%
     dplyr::filter(.data$propInMask > thresh) %>%
-    dplyr::pull(.data$trackId) %>%
+    dplyr::pull(.data[[idCol]]) %>%
     unique()
 
   return(whichInMaskLongEnough)
@@ -210,7 +211,7 @@ convertAndBuffer <- function(obj, dist = 50, crsMeters = 32636){
 #' @return an edge list (data frame)
 #' @export
 # Convert to UTM
-spaceTimeGroups <- function(dataset, distThreshold, consecThreshold = 2, crsToSet = "WGS84", crsToTransform = 32636, timestampCol = "timestamp", timeThreshold = "10 minutes", idCol = "trackId", latCol = "location_lat", longCol = "location_long", returnDist = TRUE, fillNA = FALSE, sri = T){
+spaceTimeGroups <- function(dataset, distThreshold, consecThreshold = 2, crsToSet = "WGS84", crsToTransform = 32636, timestampCol = "timestamp", timeThreshold = "10 minutes", idCol = "Nili_id", latCol = "location_lat", longCol = "location_long", returnDist = TRUE, fillNA = FALSE, sri = T){
   # argument checks
   checkmate::assertDataFrame(dataset)
   checkmate::assertNumeric(distThreshold, len = 1, lower = 0, finite = TRUE)
@@ -367,7 +368,7 @@ consecEdges <- function(edgeList, consecThreshold = 2, id1Col = "ID1", id2Col = 
 #' @param timegroupCol character. Name of the column containing timegroup values.
 #' @return A data frame containing ID1, ID2, and SRI value.
 #' @export
-calcSRI <- function(dataset, edges, idCol = "trackId", timegroupCol = "timegroup"){
+calcSRI <- function(dataset, edges, idCol = "Nili_id", timegroupCol = "timegroup"){
   # setup for time warning
   cat("\nComputing SRI... this may take a while if your dataset is large.\n")
   start <- Sys.time()

--- a/man/calcSRI.Rd
+++ b/man/calcSRI.Rd
@@ -4,7 +4,7 @@
 \alias{calcSRI}
 \title{Calculate SRI}
 \usage{
-calcSRI(dataset, edges, idCol = "trackId", timegroupCol = "timegroup")
+calcSRI(dataset, edges, idCol = "Nili_id", timegroupCol = "timegroup")
 }
 \arguments{
 \item{dataset}{the cleaned dataset.}

--- a/man/cleanData.Rd
+++ b/man/cleanData.Rd
@@ -12,6 +12,7 @@ cleanData(
   longCol = "location_long.1",
   latCol = "location_lat.1",
   dateCol = "dateOnly",
+  idCol = "Nili_id",
   removeVars = T,
   reMask = T,
   quiet = T,
@@ -33,6 +34,8 @@ cleanData(
 
 \item{dateCol}{The name of the column in the dataset containing dates. Defaults to "dateOnly". Passed to `vultureUtils::mostlyInMask()`.}
 
+\item{idCol}{The name of the column in the dataset containing vulture ID's. Defaults to "Nili_id" (assuming you have joined the Nili_ids from the who's who table).}
+
 \item{removeVars}{Whether or not to remove unnecessary variables. Default is T.}
 
 \item{reMask}{Whether or not to re-mask after removing individuals that spend less than `inMaskThreshold` in the mask area. Default is T.}
@@ -42,7 +45,7 @@ cleanData(
 \item{...}{additional arguments to be passed to any of several functions: `vultureUtils::removeUnnecessaryVars()` (`addlVars`, `keepVars`);}
 }
 \value{
-An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the trackID of the first individual in this edge, and `ID2` is the trackID of the second individual in this edge.
+An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.
 }
 \description{
 This function takes in a raw dataset downloaded from movebank, masks it, and performs basic data cleaning. The output from this function feeds directly into `vultureUtils::spaceTimeGroups()`. Steps: 1. Using the `mask` object, get a list of the individuals in `dataset` that spend at least `inMaskThreshold` proportion of their time inside the mask area. 2. Restrict `dataset` to only these individuals. 3. Re-apply the mask to restrict the remaining points to those that fall within `mask`.

--- a/man/getEdges.Rd
+++ b/man/getEdges.Rd
@@ -45,7 +45,7 @@ getEdges(
 \item{return}{One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)}
 }
 \value{
-An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the trackID of the first individual in this edge, and `ID2` is the trackID of the second individual in this edge.
+An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.
 }
 \description{
 Given a dataset of GPS points, a geographic mask, and some roost polygons, create an edge list.

--- a/man/getFeedingEdges.Rd
+++ b/man/getFeedingEdges.Rd
@@ -45,7 +45,7 @@ getFeedingEdges(
 \item{return}{One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)}
 }
 \value{
-An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the trackID of the first individual in this edge, and `ID2` is the trackID of the second individual in this edge.
+An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.
 }
 \description{
 Wrapper of getEdges() with defaults for co-feeding edges. Can still be customized!

--- a/man/getFlightEdges.Rd
+++ b/man/getFlightEdges.Rd
@@ -45,7 +45,7 @@ getFlightEdges(
 \item{return}{One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)}
 }
 \value{
-An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the trackID of the first individual in this edge, and `ID2` is the trackID of the second individual in this edge.
+An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.
 }
 \description{
 Wrapper of getEdges() with defaults for co-flight edges. Can still be customized!

--- a/man/getRoostEdges.Rd
+++ b/man/getRoostEdges.Rd
@@ -11,7 +11,7 @@ getRoostEdges(
   distThreshold = 500,
   latCol = "location_lat",
   longCol = "location_long",
-  idCol = "trackId",
+  idCol = "Nili_id",
   dateCol = "date",
   roostCol = "roostID",
   crsToSet = "WGS84",
@@ -32,7 +32,7 @@ getRoostEdges(
 
 \item{longCol}{Name of the column in `dataset` containing longitude information. Default is "location_long".}
 
-\item{idCol}{Name of the column in `dataset` containing the ID's of the vultures. Default is "trackId".}
+\item{idCol}{Name of the column in `dataset` containing the ID's of the vultures. Default is "Nili_id".}
 
 \item{dateCol}{Name of the column in `dataset` containing roost dates. Default is "date".}
 

--- a/man/mostlyInMask.Rd
+++ b/man/mostlyInMask.Rd
@@ -4,7 +4,13 @@
 \alias{mostlyInMask}
 \title{Which individuals spent time mostly in the masked area?}
 \usage{
-mostlyInMask(dataset, maskedDataset, thresh = 0.333, dateCol = "dateOnly")
+mostlyInMask(
+  dataset,
+  maskedDataset,
+  thresh = 0.333,
+  dateCol = "dateOnly",
+  idCol = "Nili_id"
+)
 }
 \arguments{
 \item{dataset}{the full dataset, before masking.}
@@ -14,9 +20,11 @@ mostlyInMask(dataset, maskedDataset, thresh = 0.333, dateCol = "dateOnly")
 \item{thresh}{proportion (between 0 and 1) of a vulture's total tracked days that it spent in Israel}
 
 \item{dateCol}{the name of the column containing dates (must be the same in `dataset` and `maskedDataset`). Defaults to "dateOnly".}
+
+\item{idCol}{the name of the column containing vulture ID's.}
 }
 \value{
-A vector of trackIds for vultures
+A vector of id's for vultures
 }
 \description{
 Compare masked and unmasked data. Return IDs of individual birds that spent at least `thresh` proportion of days in the masked area (vs. outside of the masked area). This function should be used after creating a masked dataset with vultureUtils::maskData(). Note: this function does its calculations based on numbers of *days*. Later modifications might allow for other units of time, but for now everything is in days.

--- a/man/spaceTimeGroups.Rd
+++ b/man/spaceTimeGroups.Rd
@@ -12,7 +12,7 @@ spaceTimeGroups(
   crsToTransform = 32636,
   timestampCol = "timestamp",
   timeThreshold = "10 minutes",
-  idCol = "trackId",
+  idCol = "Nili_id",
   latCol = "location_lat",
   longCol = "location_long",
   returnDist = TRUE,


### PR DESCRIPTION
New idCol args for some functions. For others, changed default from `trackId` to `Nili_id`. Removed hard-coded dependencies on `trackId`, with the exception of the manual addition of that column in `downloadVultures`.