### PR TITLE
Data cleaning report; interaction locations

### DIFF
--- a/R/mainFunctions.R
+++ b/R/mainFunctions.R
@@ -719,11 +719,15 @@ getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, dist
       purrr::map_dfr(~{tidyr::expand_grid("ID1" = .x[[idCol]], .x)}) %>% # for each polygon/day, create all pairs of individuals, and then bind the results back together into a data frame.
 
       dplyr::rename("ID2" = {{idCol}}) %>%
-      dplyr::filter(ID1 < ID2) # remove self and duplicate edges
+      dplyr::filter(ID1 < ID2) %>% # remove self and duplicate edges
+      dplyr::select(-c("sunrise", "sunset", "sunrise_twilight", "sunset_twilight", "daylight", "is_roost"))
   }
 
   locsColNames <- c("latID1", "longID1", "latID2", "longID2", "interactionLat", "interactionLong")
-  if(!getLocs & !is.null(edges)){
+  if(!getLocs & !is.null(edges) & mode == "polygon"){
+    edges <- edges %>%
+      dplyr::select(-c(latCol, longCol, roostCol))
+  }else if(!getLocs & !is.null(edges) & mode != "polygon"){
     edges <- edges %>%
       dplyr::select(-any_of(locsColNames))
   }

--- a/R/mainFunctions.R
+++ b/R/mainFunctions.R
@@ -660,6 +660,8 @@ getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, dist
       stop("Wrong number of rows!") # XXX need to better address this error.
     }
 
+    edges <- ef
+
   }else{
     ## POLYGON MODE
     # Polygon assignment is triggered if the roostID column is missing and there are some polygons provided.
@@ -718,6 +720,12 @@ getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, dist
 
       dplyr::rename("ID2" = {{idCol}}) %>%
       dplyr::filter(ID1 < ID2) # remove self and duplicate edges
+  }
+
+  locsColNames <- c("latID1", "longID1", "latID2", "longID2", "interactionLat", "interactionLong")
+  if(!getLocs & !is.null(edges)){
+    edges <- edges %>%
+      dplyr::select(-any_of(locsColNames))
   }
 
   # now we have either distanceEdges or polygonEdges. Now need to determine whether to calculate SRI or not.

--- a/R/mainFunctions.R
+++ b/R/mainFunctions.R
@@ -266,7 +266,7 @@ cleanData <- function(dataset, mask, inMaskThreshold = 0.33, crs = "WGS84", long
       dplyr::filter(.data[[idCol]] %in% longEnoughIndivs)
     firstMask <- getStats(dataset)
   }else{
-    firstMask <- rep(NA, 3)
+    firstMask <- c("rows" = NA, "cols" = NA, "indivs" = NA) # AAA
   }
 
 
@@ -286,7 +286,7 @@ cleanData <- function(dataset, mask, inMaskThreshold = 0.33, crs = "WGS84", long
     secondMask <- getStats(cleanedInMask) # AAA
     out <- cleanedInMask
   }else{
-    secondMask <- rep(NA, 3) # AAA
+    secondMask <- c("rows" = NA, "cols" = NA, "indivs" = NA) # AAA
     out <- dataset
   }
   final <- getStats(out) # AAA

--- a/R/mainFunctions.R
+++ b/R/mainFunctions.R
@@ -725,8 +725,9 @@ getRoostEdges <- function(dataset, mode = "distance", roostPolygons = NULL, dist
 
   locsColNames <- c("latID1", "longID1", "latID2", "longID2", "interactionLat", "interactionLong")
   if(!getLocs & !is.null(edges) & mode == "polygon"){
-    edges <- edges %>%
-      dplyr::select(-c(latCol, longCol, roostCol))
+    edges[[latCol]] <- NULL
+    edges[[longCol]] <- NULL
+    edges[[roostCol]] <- NULL
   }else if(!getLocs & !is.null(edges) & mode != "polygon"){
     edges <- edges %>%
       dplyr::select(-any_of(locsColNames))

--- a/R/supportingFunctions.R
+++ b/R/supportingFunctions.R
@@ -269,7 +269,7 @@ spaceTimeGroups <- function(dataset, distThreshold, consecThreshold = 2, crsToSe
   # Group the points into timegroups using spatsoc::group_times.
   dataset <- spatsoc::group_times(dataset, datetime = timestampCol, threshold = timeThreshold)
   timegroupData <- dataset %>%
-    dplyr::select(all_of(timestampCol), timegroup) %>% # save information about when each timegroup starts and ends.
+    dplyr::select(tidyselect::all_of(timestampCol), timegroup) %>% # save information about when each timegroup starts and ends.
     dplyr::group_by(timegroup) %>%
     dplyr::summarize(minTimestamp = min(.data[[timestampCol]], na.rm = T),
                      maxTimestamp = max(.data[[timestampCol]], na.rm = T))
@@ -332,7 +332,7 @@ consecEdges <- function(edgeList, consecThreshold = 2, id1Col = "ID1", id2Col = 
   checkmate::assertInteger(edgeList[[timegroupCol]])
 
   uniquePairs <- edgeList %>%
-    dplyr::select(.data[[id1Col]], .data[[id2Col]], .data[[timegroupCol]]) %>%
+    dplyr::select(tidyselect::all_of(c(id1Col, id2Col, timegroupCol))) %>%
     dplyr::distinct(.data[[timegroupCol]], .data[[id1Col]], .data[[id2Col]]) %>%
     # for each edge, arrange by timegroup
     dplyr::group_by(.data[[id1Col]], .data[[id2Col]]) %>%
@@ -349,7 +349,7 @@ consecEdges <- function(edgeList, consecThreshold = 2, id1Col = "ID1", id2Col = 
     dplyr::select(-grp)
 
   consec <- uniquePairs_toKeep %>%
-    left_join(edgeList, by = c(id1Col, id2Col, timegroupCol))
+    dplyr::left_join(edgeList, by = c(id1Col, id2Col, timegroupCol))
 
   return(consec)
 }

--- a/man/cleanData.Rd
+++ b/man/cleanData.Rd
@@ -16,7 +16,7 @@ cleanData(
   removeVars = T,
   reMask = T,
   quiet = T,
-  downsample = T,
+  report = T,
   ...
 )
 }
@@ -43,7 +43,7 @@ cleanData(
 
 \item{quiet}{Whether to silence the message that happens when doing spatial joins. Default is T.}
 
-\item{downsample}{T/F. Whether to downsample the data to a 10 min interval. #XXX expand functionality here, or consider making it a separate function. This is quick and dirty. Also fix the actual downsampling, because I don't think it's quite right.}
+\item{report}{Default TRUE. Whether to print a report of how many rows/individuals were removed in each of the data cleaning steps.}
 
 \item{...}{additional arguments to be passed to any of several functions: `vultureUtils::removeUnnecessaryVars()` (`addlVars`, `keepVars`);}
 }

--- a/man/filterLocs.Rd
+++ b/man/filterLocs.Rd
@@ -21,7 +21,7 @@ filterLocs(
 \item{speedCol}{Name of the column containing ground speed values. Default is "ground_speed".}
 }
 \value{
-A list of filtered data frames.
+A filtered data frame
 }
 \description{
 Filter dataset for reasonableness

--- a/man/getEdges.Rd
+++ b/man/getEdges.Rd
@@ -17,7 +17,8 @@ getEdges(
   quiet = T,
   includeAllVertices = F,
   daytimeOnly = T,
-  return = "edges"
+  return = "edges",
+  getLocs = FALSE
 )
 }
 \arguments{
@@ -46,6 +47,8 @@ getEdges(
 \item{daytimeOnly}{T/F, whether to restrict interactions to daytime only. Default is T.}
 
 \item{return}{One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)}
+
+\item{getLocs}{Whether or not to return locations where the interactions happened (for edge list only, doesn't make sense for SRI). Default is FALSE. If getLocs is set to TRUE when return = "sri", a message will tell the user that no locations can be returned for SRI.}
 }
 \value{
 An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.

--- a/man/getFeedingEdges.Rd
+++ b/man/getFeedingEdges.Rd
@@ -17,7 +17,8 @@ getFeedingEdges(
   quiet = T,
   includeAllVertices = F,
   daytimeOnly = T,
-  return = "edges"
+  return = "edges",
+  getLocs = FALSE
 )
 }
 \arguments{
@@ -46,6 +47,8 @@ getFeedingEdges(
 \item{daytimeOnly}{T/F, whether to restrict interactions to daytime only. Default is T.}
 
 \item{return}{One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)}
+
+\item{getLocs}{Whether or not to return locations where the interactions happened (for edge list only, doesn't make sense for SRI). Default is FALSE. If getLocs is set to TRUE when return = "sri", a message will tell the user that no locations can be returned for SRI.}
 }
 \value{
 An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.

--- a/man/getFlightEdges.Rd
+++ b/man/getFlightEdges.Rd
@@ -17,7 +17,8 @@ getFlightEdges(
   quiet = T,
   includeAllVertices = F,
   daytimeOnly = T,
-  return = "edges"
+  return = "edges",
+  getLocs = FALSE
 )
 }
 \arguments{
@@ -46,6 +47,8 @@ getFlightEdges(
 \item{daytimeOnly}{T/F, whether to restrict interactions to daytime only. Default is T.}
 
 \item{return}{One of "edges" (default, returns an edgelist, would need to be used in conjunction with includeAllVertices = T in order to include all individuals, since otherwise they wouldn't be included in the edgelist. Also includes timegroup information, which SRI cannot do. One row in this data frame represents a single edge in a single timegroup.); "sri" (returns a data frame with three columns, ID1, ID2, and sri. Includes pairs whose SRI values are 0, which means it includes all individuals and renders includeAllVertices obsolete.); and "both" (returns a list with two components: "edges" and "sri" as described above.)}
+
+\item{getLocs}{Whether or not to return locations where the interactions happened (for edge list only, doesn't make sense for SRI). Default is FALSE. If getLocs is set to TRUE when return = "sri", a message will tell the user that no locations can be returned for SRI.}
 }
 \value{
 An edge list containing the following columns: `timegroup` gives the numeric index of the timegroup during which the interaction takes place. `minTimestamp` and `maxTimestamp` give the beginning and end times of that timegroup. `ID1` is the id of the first individual in this edge, and `ID2` is the id of the second individual in this edge.

--- a/tests/testthat/test-mainFunctions.R
+++ b/tests/testthat/test-mainFunctions.R
@@ -72,6 +72,7 @@ test_that("getRoostEdges works", {
   rp <- sf::st_read(test_path("testdata", "roosts25_cutOffRegion.kml")) # roost polygons
   r <- get_roosts_df(df = a, id = "id")
   dist_e <- getRoostEdges(r, mode = "distance", idCol = "id", return = "edges")
+  dist_e_locs <- getRoostEdges(r, mode = "distance", idCol = "id", return = "edges", getLocs = TRUE)
   poly_e <- getRoostEdges(r, mode = "polygon", roostPolygons = rp, idCol = "id", return = "edges")
   dist_s <- getRoostEdges(r, mode = "distance", idCol = "id", return = "sri")
   poly_s <- getRoostEdges(r, mode = "polygon", roostPolygons = rp, idCol = "id", return = "sri")

--- a/tests/testthat/test-mainFunctions.R
+++ b/tests/testthat/test-mainFunctions.R
@@ -9,9 +9,11 @@ test_that("getFeedingEdges works", {
 
   # produce some interactions
   edges <- getFeedingEdges(dataset = a, roostPolygons = rp, idCol = "id", return = "edges")
+  edgesLocs <- getFeedingEdges(dataset = a, roostPolygons = rp, idCol = "id", return = "edges", getLocs = T)
   ind <- getFeedingEdges(dataset = a, roostPolygons = rp, idCol = "id", return = "edges", includeAllVertices = T)
   sri <- getFeedingEdges(dataset = a, roostPolygons = rp, idCol = "id", return = "sri")
   both <- getFeedingEdges(dataset = a, roostPolygons = rp, idCol = "id", return = "both")
+  bothLocs <- getFeedingEdges(dataset = a, roostPolygons = rp, idCol = "id", return = "both", getLocs = T)
   o <- capture_output(getFeedingEdges(dataset = a, roostPolygons = rp, idCol = "id", return = "sri"))
   expect_match(o, "Computing SRI... this may take a while if your dataset is large.", all = FALSE)
   expect_match(o, "SRI computation completed in", all = FALSE)
@@ -22,6 +24,10 @@ test_that("getFeedingEdges works", {
   expect_equal(class(both[[2]]), "data.frame")
   expect_equal(class(ind), "list")
   expect_equal(class(ind[[2]]), "character")
+  expect_equal(ncol(edgesLocs) > ncol(edges), T)
+  expect_equal(ncol(bothLocs$edges) > ncol(both$edges), T)
+  expect_equal(all(c("latID1", "longID1", "latID2", "longID2", "interactionLat", "interactionLong") %in% names(edgesLocs)), T)
+  expect_equal(all(c("latID1", "longID1", "latID2", "longID2", "interactionLat", "interactionLong") %in% names(bothLocs$edges)), T)
 
   # quiet = F
   output_qf <- capture_output(getFeedingEdges(dataset = a, roostPolygons = rp, idCol = "id", return = "edges", quiet = F))

--- a/tests/testthat/test-mainFunctions.R
+++ b/tests/testthat/test-mainFunctions.R
@@ -86,18 +86,13 @@ test_that("cleanData works", {
   b <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, reMask = F) # not re-masked
   c_notRemoved <- cleanData(a, mask = mask, idCol = "trackId", removeVars = F)
 
-  # not downsampled
-  nd <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, downsample = F)
-
   # not quiet
   nq <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, quiet = F)
 
   # expectations
   expect_equal(ncol(c_notRemoved) > ncol(c), TRUE) # more vars if not removed (duh)
   expect_equal(class(c), c("sf", "tbl_df", "tbl", "data.frame")) # expected classes
-  expect_equal(class(nd), class(c)) # class shouldn't change if you don't downsample the data
   expect_equal(class(b), c("tbl_df", "tbl", "data.frame")) # if we don't re-mask, the resulting object doesn't have class sf. #XXX should look into fixing this to make it consistent.
-  expect_equal(nrow(nd) > nrow(c), TRUE) # there should be more data if we don't downsample
   expect_equal(nq, c) # setting quiet = F should not change the output
   o <- capture_messages(cleanData(a, mask = mask, idCol = "trackId", removeVars = T, quiet = F))
   expect_match(o, "dropping Z and/or M coordinate", all = FALSE)

--- a/tests/testthat/test-mainFunctions.R
+++ b/tests/testthat/test-mainFunctions.R
@@ -74,6 +74,7 @@ test_that("getRoostEdges works", {
   dist_e <- getRoostEdges(r, mode = "distance", idCol = "id", return = "edges")
   dist_e_locs <- getRoostEdges(r, mode = "distance", idCol = "id", return = "edges", getLocs = TRUE)
   poly_e <- getRoostEdges(r, mode = "polygon", roostPolygons = rp, idCol = "id", return = "edges")
+  poly_e_locs <- getRoostEdges(r, mode = "polygon", roostPolygons = rp, idCol = "id", return = "edges", getLocs = TRUE)
   dist_s <- getRoostEdges(r, mode = "distance", idCol = "id", return = "sri")
   poly_s <- getRoostEdges(r, mode = "polygon", roostPolygons = rp, idCol = "id", return = "sri")
 
@@ -82,6 +83,10 @@ test_that("getRoostEdges works", {
   expect_equal(class(poly_e), c("tbl_df", "tbl", "data.frame"))
   expect_equal(class(dist_s), "data.frame")
   expect_equal(class(poly_s), "data.frame")
+  expect_equal(ncol(dist_e_locs) > ncol(dist_e), TRUE)
+  expect_equal(ncol(poly_e_locs) > ncol(poly_e), TRUE)
+  expect_equal(all(c("location_lat", "location_long", "roostID") %in% names(poly_e_locs)), TRUE)
+  expect_equal(all(c("latID1", "longID1", "latID2", "longID2", "interactionLat", "interactionLong") %in% names(dist_e_locs)), TRUE)
 })
 
 # cleanData


### PR DESCRIPTION
1. Added a data cleaning report to cleanData, to show how many rows and individuals were lost at each step.
2. Added interaction locations to getEdges and getRoostEdges, with a parameter getLocs (default FALSE) for getEdges, getFeedingEdges, getRoostEdges, and getFlightEdges. Only makes a difference for return = "edges" or return = "both". Can't really return a location for SRI--by definition it's multiple locations. 