### PR TITLE
Changes to cleanData--durations

### DIFF
--- a/R/mainFunctions.R
+++ b/R/mainFunctions.R
@@ -80,7 +80,7 @@ downloadVultures <- function(loginObject, extraSensors = F, removeDup = T,
 #' @param dataset The GPS dataset to be used to create the edge list. Must contain columns specified by `longCol`, `latCol`, and `dateCol` args. Must also contain columns "gps_time_to_fix", "heading", "gps_satellite_count", and "ground_speed" because data cleaning is based on this info. Note that because of how the masking is conducted in `mostlyInMask`, the data is grouped into single days. As a result, `dataset` must contain at least 1 day's worth of data in order for the output of this function to have any rows.
 #' @param removeVars Whether or not to remove unnecessary variables from movebank download. Default is T.
 #' @param mask The object to use to mask the data. Passed to `vultureUtils::maskData()`. Must be an sf object.
-#' @param inMaskThreshold Proportion of an individual's days tracked that must fall within the mask. Default is 0.33 (one third of days tracked). Passed to `vultureUtils::mostlyInMask()`. Must be numeric.
+#' @param inMaskThreshold Proportion of an individual's days tracked that must fall within the mask. Default is 0.33 (one third of days tracked). If a number >1 is supplied, will be interpreted as number of days that fall in the mask. Passed to `vultureUtils::mostlyInMask()`. Must be numeric.
 #' @param crs Coordinate Reference System to check for and transform to, for both the GPS data and the mask. Default is "WGS84". This value is passed to `vultureUtils::maskData()`. Must be a valid CRS or character string coercible to CRS.
 #' @param longCol The name of the column in the dataset containing longitude values. Defaults to "location_long.1". Passed to `vultureUtils::maskData()`.
 #' @param latCol The name of the column in the dataset containing latitude values. Defaults to "location_lat.1". Passed to `vultureUtils::maskData()`.
@@ -97,7 +97,7 @@ cleanData <- function(dataset, mask, inMaskThreshold = 0.33, crs = "WGS84", long
   # Argument checks
   checkmate::assertClass(mask, "sf")
   checkmate::assertDataFrame(dataset)
-  checkmate::assertNumeric(inMaskThreshold, len = 1, lower = 0, upper = 1, null.ok = TRUE)
+  checkmate::assertNumeric(inMaskThreshold, len = 1, null.ok = TRUE)
   checkmate::assertCharacter(longCol, len = 1)
   checkmate::assertCharacter(latCol, len = 1)
   checkmate::assertCharacter(dateCol, len = 1)

--- a/R/supportingFunctions.R
+++ b/R/supportingFunctions.R
@@ -70,25 +70,19 @@ mostlyInMask <- function(dataset, maskedDataset, thresh = 0.333, dateCol = "date
   # Look at date durations in the full dataset
   dates <- dataset %>%
     dplyr::group_by(.data[[idCol]]) %>%
-    dplyr::summarize(duration = as.numeric(max(.data[[dateCol]],
-                                               na.rm = T) - min(.data[[dateCol]],
-                                                                na.rm = T)),
-                     nDays = length(unique(.data[[dateCol]])))
+    dplyr::summarize(nDays = length(unique(.data[[dateCol]])))
 
 
   # Look at date durations in the masked Israel dataset
   datesInMask <- maskedDataset %>%
     as.data.frame() %>%
     dplyr::group_by(.data[[idCol]]) %>%
-    dplyr::summarize(durationInMask =
-                       as.numeric(max(.data[[dateCol]], na.rm = T) -
-                                    min(.data[[dateCol]], na.rm = T)),
-                     nDaysInMask = length(unique(.data[[dateCol]])))
+    dplyr::summarize(nDaysInMask = length(unique(.data[[dateCol]])))
 
   # Compare the two dates and calculate proportion
   datesCompare <- dplyr::left_join(dates, datesInMask %>%
-                                     dplyr::select(tidyselect::all_of(idCol), durationInMask, nDaysInMask)) %>%
-    dplyr::mutate(propDurationInMask = .data$durationInMask/.data$duration) # compute proportion of days spent in the mask a
+                                     dplyr::select(tidyselect::all_of(idCol), nDaysInMask)) %>%
+    dplyr::mutate(propDaysInMask = .data$nDaysInMask/.data$nDays) # compute proportion of days spent in the mask a
 
   if(thresh > 1){
     print("thresholding by number of days")
@@ -99,7 +93,7 @@ mostlyInMask <- function(dataset, maskedDataset, thresh = 0.333, dateCol = "date
   }else{
     print("thresholding by proportion of duration")
     whichInMaskLongEnough <- datesCompare %>%
-      dplyr::filter(.data$propDurationInMask > thresh) %>%
+      dplyr::filter(.data$propDaysInMask > thresh) %>%
       dplyr::pull(.data[[idCol]]) %>%
       unique()
   }

--- a/tests/testthat/test-mainFunctions.R
+++ b/tests/testthat/test-mainFunctions.R
@@ -98,7 +98,7 @@ test_that("cleanData works", {
   b <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, reMask = F) # not re-masked
   c_notRemoved <- cleanData(a, mask = mask, idCol = "trackId", removeVars = F)
 
-  c_2 <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, inMaskThreshold = 2)
+  c_2 <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, inMaskThreshold = 1.5)
 
   # not quiet
   nq <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, quiet = F)

--- a/tests/testthat/test-mainFunctions.R
+++ b/tests/testthat/test-mainFunctions.R
@@ -98,6 +98,8 @@ test_that("cleanData works", {
   b <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, reMask = F) # not re-masked
   c_notRemoved <- cleanData(a, mask = mask, idCol = "trackId", removeVars = F)
 
+  c_2 <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, inMaskThreshold = 2)
+
   # not quiet
   nq <- cleanData(a, mask = mask, idCol = "trackId", removeVars = T, quiet = F)
 


### PR DESCRIPTION
Changed to proportion of number of days instead of proportion of duration of days, in case there are missed days between min and max date (oops).

Also added handling for the threshold parameter being set to > 1. If >1, it will be interpreted as a number of days. If < 1, it will be interpreted as a proportion.

This is an extremely clumsy handling of this, and it should be made better. 